### PR TITLE
add debug to various public data structures and inline to vertex_label

### DIFF
--- a/src/adjacency_list.rs
+++ b/src/adjacency_list.rs
@@ -36,7 +36,7 @@ impl Encodable for AdjacencyListEdgeDescriptor {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AdjacencyList<N,E> {
     vertex_labels:  HashMap<AdjacencyListVertexDescriptor,N>,
     edge_labels:    HashMap<AdjacencyListEdgeDescriptor,E>,
@@ -47,6 +47,7 @@ pub struct AdjacencyList<N,E> {
     next_vertex:    AdjacencyListVertexDescriptor
 }
 
+#[derive(Debug)]
 pub struct AdjacencyListAdjacency {
     adj: Box<Vec<AdjacencyListVertexDescriptor>>
 }
@@ -77,6 +78,7 @@ impl<'a,V,E> Graph<'a,V,E> for AdjacencyList<V,E> {
     type Vertex = AdjacencyListVertexDescriptor;
     type Edge = AdjacencyListEdgeDescriptor;
 
+    #[inline]
     fn vertex_label(&self, n: Self::Vertex) -> Option<&V> {
         return self.vertex_labels.get(&n);
     }

--- a/src/adjacency_matrix.rs
+++ b/src/adjacency_matrix.rs
@@ -7,6 +7,7 @@ pub struct AdjacencyMatrixEdgeDescriptor {
     to: usize,
 }
 
+#[derive(Debug)]
 pub struct AdjacencyMatrix<'a,V:'a,E:'a> {
     edges: &'a [&'a [Option<E>]],
     vertex_labels: &'a [V],
@@ -54,6 +55,7 @@ impl<'a,V,E> AdjacencyMatrixGraph<'a,V,E> for AdjacencyMatrix<'a,V,E> {
     }
 }
 
+#[derive(Debug)]
 pub struct AdjacencyMatrixNeight<'a,V:'a,E:'a> {
     fix: usize,
     var: Range<usize>,
@@ -123,6 +125,7 @@ impl<'a,V,E> BidirectionalGraph<'a,V,E> for AdjacencyMatrix<'a,V,E> {
     }
 }
 
+#[derive(Debug)]
 pub struct AdjacencyMatrixAdjacency {
     adj: Box<Vec<usize>>
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,6 +5,7 @@ pub trait Graph<'a,V,E> {
     type Edge: Clone + Hash + PartialEq + Eq + Copy;
 
     fn edge_label(&self,Self::Edge) -> Option<&E>;
+    #[inline]
     fn vertex_label(&self,Self::Vertex) -> Option<&V>;
     fn source(&self,Self::Edge) -> Self::Vertex;
     fn target(&self,Self::Edge) -> Self::Vertex;


### PR DESCRIPTION
When debugging panopticon I frequently want to just pretty print the state of project, or the cfg, using `println!("{:#?}")` without any hassle, but lack of debug impls here prevents that, which can be frustrating.

I also added inline to `vertex_label` as this is showing up as a frequent hotspot in various perfs; inline reduces the hash lookup to one less call, and also lets perf tools do a better job of locating the real hotspot. But feel free to remove this.
